### PR TITLE
Fix setup on Python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,6 @@ setup(
     license='Expat license',
     py_modules=['mccabe'],
     zip_safe=False,
-    install_requires=[
-        'setuptools',
-    ],
     entry_points={
         'flake8.extension': [
             'C90 = mccabe:McCabeChecker',


### PR DESCRIPTION
The [flake8 install issues on Python 3](https://bitbucket.org/tarek/flake8/pull-request/32/fixing-install-problem-for-python-3/diff) are still valid as long as mccabe requires setuptools.
