### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [bdist_wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [aliases]
 test = pytest


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

The wheel now complies with the license:

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.