### PR TITLE
Problem: Docstrings were handled differently on 3.7.0b4

### DIFF
--- a/test_mccabe.py
+++ b/test_mccabe.py
@@ -18,7 +18,7 @@ trivial = 'def f(): pass'
 
 expr_as_statement = '''\
 def f():
-    """docstring"""
+    0xF00D
 '''
 
 


### PR DESCRIPTION
This caused an increased complexity number on 3.7.0b4 when docstring was used in the expr_as_statement test.

Solution:

While this change in Python will most likely get reverted according to [1], we decided to use a non-docstring expression in the test to avoid this problem in the future if docstring handling ever gets changed again.

Fixes https://github.com/PyCQA/mccabe/issues/61

[1]: https://github.com/PyCQA/mccabe/issues/61#issuecomment-393137462