### PR TITLE
Remove Python 3.3 trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Testing was dropped in de233b7bc6738a0e6366632ab37ec6c1fccfac1d.

Python 3.3 is end of life. It is no longer receiving bug fixes, including for security issues. Python 3.3 went EOL on 2017-09-29. For additional details on support Python versions, see:

https://devguide.python.org/#status-of-python-branches

For details on the Python 3.3 release schedule, see:

https://www.python.org/dev/peps/pep-0398/