### PR TITLE
Check entire project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,20 @@ The complexity checker can be used directly::
   ("257:1: 'get_code_complexity'", 5)
 
 
+Analyze Project
+---------------
+
+You can analyze an entire codebase with the `-p` or `--project` and specifying a directory::
+
+  $ python -m mccabe --min 5 -p project_name
+  ("185:1: 'PathGraphingAstVisitor.visitIf'", 5)
+  ("71:1: 'PathGraph.to_dot'", 5)
+  ("245:1: 'McCabeChecker.run'", 5)
+  ("283:1: 'main'", 7)
+  ("203:1: 'PathGraphingAstVisitor.visitTryExcept'", 5)
+  ("257:1: 'get_code_complexity'", 5)
+
+
 Plugin for Flake8
 -----------------
 

--- a/mccabe.py
+++ b/mccabe.py
@@ -336,7 +336,10 @@ def main(argv=None):
 
     to_analyze = []
     if options.is_project:
-        for dirpath, _, filenames in os.walk(argv[1]):
+        directory = argv[1]
+        if not argv[1].startswith('/'):
+            directory = '{}/{}'.format(os.getcwd(), argv[1])
+        for dirpath, _, filenames in os.walk(directory):
             for filename in filenames:
                 if filename.endswith('.py'):
                     to_analyze.append(process_file('{}/{}'.format(dirpath, filename)))


### PR DESCRIPTION
Added an option to args to allow the checker to run for an entire folder.

If you specify a directory like `/Users/whatever` it'll look there, otherwise it will search in the current working directory. 

Also added some validation for the arguments passed to the main entry. 

I made these changes _before_ I discovered `radon` but I figured I'd do a PR anyway because it's a pretty helpful option anyway.