### PR TITLE
Add console_scripts entry point.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ setup(
         'flake8.extension': [
             'C90 = mccabe:McCabeChecker',
         ],
+        'console_scripts': [
+            'mccabe = mccabe:main',
+        ],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Adding the entry point allows me to use the package with [pipx](https://github.com/pipxproject/pipx). 

With the entry point it can be used also as `mccabe <file>` in addition to the original `python -m mccabe <file>`.