### PR TITLE
Remove use of deprecated 'setup.py test'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ universal = 1
 
 [metadata]
 license_file = LICENSE
-
-[aliases]
-test = pytest

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
-import sys
 
 from setuptools import setup
-
-needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 
 def get_version(fname='mccabe.py'):
@@ -37,8 +33,6 @@ setup(
     license='Expat license',
     py_modules=['mccabe'],
     zip_safe=False,
-    setup_requires=pytest_runner,
-    tests_require=['pytest'],
     entry_points={
         'flake8.extension': [
             'C90 = mccabe:McCabeChecker',

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ envlist =
 
 [testenv]
 deps =
+    pytest
 commands =
-    python setup.py test -q
+    pytest
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command is formally
deprecated and should not be used.

The pytest-runner package also lists itself as deprecated:
https://github.com/pytest-dev/pytest-runner

> Deprecation Notice
>
> pytest-runner depends on deprecated features of setuptools and relies
> on features that break security mechanisms in pip. For example
> 'setup_requires' and 'tests_require' bypass pip --require-hashes. See
> also pypa/setuptools#1684.