### PR TITLE
Update the test matrix to include Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 before_script:
   - pip install tox
 script:
@@ -19,10 +18,12 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
-      sudo: true
+    - python: 3.8
+      env: TOXENV=py38
     - python: pypy
       env: TOXENV=pypy
+    - python: pypy3
+      env: TOXENV=pypy3
     - env: TOXENV=docstrings
     - env: TOXENV=flake8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ universal = 1
 
 [metadata]
 license_file = LICENSE
-
-[aliases]
-test = pytest

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
-import sys
 
 from setuptools import setup
-
-needs_pytest = set(['pytest', 'test', 'ptr']).intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 
 def get_version(fname='mccabe.py'):
@@ -37,8 +33,6 @@ setup(
     license='Expat license',
     py_modules=['mccabe'],
     zip_safe=False,
-    setup_requires=pytest_runner,
-    tests_require=['pytest'],
     entry_points={
         'flake8.extension': [
             'C90 = mccabe:McCabeChecker',

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ envlist =
 
 [testenv]
 deps =
+    pytest
 commands =
-    python setup.py test -q
+    pytest
 
 [testenv:flake8]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,py37,flake8
+    py27,py34,py35,py36,py37,py38,pypy,pypy3,flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
Test Python 3.8 and pypy3.

Drop use of 'dist: xenial' from the Travis configuration, it is now the default.

Drop use of 'sudo' from the Travis configuration, it is now deprecated.