### PR TITLE
Migrate to argparse callable `type=` option

### DIFF
--- a/mccabe.py
+++ b/mccabe.py
@@ -242,7 +242,7 @@ class McCabeChecker(object):
         kwargs = {
             'default': -1,
             'action': 'store',
-            'type': 'int',
+            'type': int,
             'help': 'McCabe complexity threshold',
             'parse_from_config': 'True',
         }


### PR DESCRIPTION
Fixes #82.