### PR TITLE
Travis CI: allow_failures in Python end of life branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ jobs:
   fast_finish: true
   allow_failures:
     - env: TOXENV=docstrings
+    - env: TOXENV=py27
+    - env: TOXENV=py34
+    - env: TOXENV=py35
+    - env: TOXENV=pypy
   include:
     - python: 2.7
       env: TOXENV=py27

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     flake8
     flake8-docstrings
 commands =
-    flake8
+    flake8 --max-line-length=88
 
 [testenv:release]
 deps =


### PR DESCRIPTION
Related to the changes in #81
https://devguide.python.org/#status-of-python-branches vs.
https://devguide.python.org/devcycle/#end-of-life-branches