### PR TITLE
Fix handling missing hypothesmith gracefully

### DIFF
--- a/test_mccabe.py
+++ b/test_mccabe.py
@@ -239,41 +239,43 @@ class RegressionTests(unittest.TestCase):
         self.assertEqual(0, mccabe.get_module_complexity("mccabe.py"))
 
 
-# This test uses the Hypothesis and Hypothesmith libraries to generate random
-# syntatically-valid Python source code and applies McCabe on it.
-@settings(
-    max_examples=1000,  # roughly 1k tests/minute, or half that under coverage
-    derandomize=False,  # deterministic mode to avoid CI flakiness
-    deadline=None,  # ignore Hypothesis' health checks; we already know that
-    suppress_health_check=HealthCheck.all(),  # this is slow and filter-heavy.
-)
-@given(
-    # Note that while Hypothesmith might generate code unlike that written by
-    # humans, it's a general test that should pass for any *valid* source code.
-    # (so e.g. running it against code scraped of the internet might also help)
-    src_contents=hypothesmith.from_grammar() | hypothesmith.from_node(),
-    max_complexity=st.integers(min_value=1),
-)
-@pytest.mark.skipif(not hypothesmith, reason="hypothesmith could not be imported")
-def test_idempotent_any_syntatically_valid_python(
-    src_contents: str, max_complexity: int
-) -> None:
-    """Property-based tests for mccabe.
+if hypothesmith is not None:
+    # This test uses the Hypothesis and Hypothesmith libraries to generate random
+    # syntatically-valid Python source code and applies McCabe on it.
+    @settings(
+        max_examples=1000,  # roughly 1k tests/minute, or half that under coverage
+        derandomize=False,  # deterministic mode to avoid CI flakiness
+        deadline=None,  # ignore Hypothesis' health checks; we already know that
+        suppress_health_check=HealthCheck.all(),  # this is slow and filter-heavy.
+    )
+    @given(
+        # Note that while Hypothesmith might generate code unlike that written by
+        # humans, it's a general test that should pass for any *valid* source code.
+        # (so e.g. running it against code scraped of the internet might also help)
+        src_contents=hypothesmith.from_grammar() | hypothesmith.from_node(),
+        max_complexity=st.integers(min_value=1),
+    )
+    @pytest.mark.skipif(not hypothesmith, reason="hypothesmith could not be imported")
+    def test_idempotent_any_syntatically_valid_python(
+        src_contents: str, max_complexity: int
+    ) -> None:
+        """Property-based tests for mccabe.
 
-    This test case is based on a similar test for Black, the code formatter.
-    Black's test was written by Zac Hatfield-Dodds, the author of Hypothesis
-    and the Hypothesmith tool for source code generation.  You can run this
-    file with `python`, `pytest`, or (soon) a coverage-guided fuzzer Zac is
-    working on.
-    """
+        This test case is based on a similar test for Black, the code formatter.
+        Black's test was written by Zac Hatfield-Dodds, the author of Hypothesis
+        and the Hypothesmith tool for source code generation.  You can run this
+        file with `python`, `pytest`, or (soon) a coverage-guided fuzzer Zac is
+        working on.
+        """
 
-    # Before starting, let's confirm that the input string is valid Python:
-    compile(src_contents, "<string>", "exec")  # else bug is in hypothesmith
+        # Before starting, let's confirm that the input string is valid Python:
+        compile(src_contents, "<string>", "exec")  # else bug is in hypothesmith
 
-    # Then try to apply get_complexity_number to the code...
-    get_code_complexity(src_contents, max_complexity)
+        # Then try to apply get_complexity_number to the code...
+        get_code_complexity(src_contents, max_complexity)
 
 
 if __name__ == "__main__":
-    test_idempotent_any_syntatically_valid_python()
+    if hypothesmith is not None:
+        test_idempotent_any_syntatically_valid_python()
     unittest.main()


### PR DESCRIPTION
Fix test_mccabe not to fail to import if hypothesmith is not available.
While the original code seems to attempt to handle missing hypothesmith,
the file fails with NameError without it.  This is because hypothesis
decorators are used in global scope.  Guard the whole test function
to be defined only when hypothesmith is available.