### PR TITLE
Fix a typo in README.rst (release date)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Links
 Changes
 -------
 
-0.7.0 - 2021-01-23
+0.7.0 - 2022-01-23
 ``````````````````
 
 * Drop support for all versions of Python lower than 3.6


### PR DESCRIPTION
0.7.0 was released on 2022-1-23, not 2021-1-23.