### PR TITLE
Improve error message on 0 arguments

### DIFF
--- a/mccabe.py
+++ b/mccabe.py
@@ -323,6 +323,9 @@ def main(argv=None):
                     default=1)
 
     options, args = opar.parse_args(argv)
+    if not args:
+        opar.print_help()
+        opar.exit()
 
     code = _read(args[0])
     tree = compile(code, args[0], "exec", ast.PyCF_ONLY_AST)


### PR DESCRIPTION
Closes #104

Here's how the output looks after the patch:

```
» python -m mccabe
Usage: mccabe.py [options]

Options:
  -h, --help            show this help message and exit
  -d, --dot             output a graphviz dot file
  -m THRESHOLD, --min=THRESHOLD
                        minimum complexity for output

```