### PR TITLE
Add console_scripts entry point

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,14 @@ The complexity checker can be used directly::
   ("203:1: 'PathGraphingAstVisitor.visitTryExcept'", 5)
   ("257:1: 'get_code_complexity'", 5)
 
+If your Python environment is added to $PATH, it can also be used as a console script entry point::
+
+  $ mccabe --min 5 mccabe
+  192:4: 'PathGraphingAstVisitor._subgraph_parse' 5
+  273:0: 'get_code_complexity' 5
+  298:0: '_read' 5
+  315:0: 'main' 8
+
 
 Plugin for Flake8
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ The complexity checker can be used directly::
 
 If your Python environment is added to $PATH, it can also be used as a console script entry point::
 
-  $ mccabe --min 5 mccabe
+  $ mccabe --min 5 mccabe.py
   192:4: 'PathGraphingAstVisitor._subgraph_parse' 5
   273:0: 'get_code_complexity' 5
   298:0: '_read' 5

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "flake8.extension": [
             "C90 = mccabe:McCabeChecker",
         ],
+        'console_scripts': ['mccabe=mccabe:main'],
     },
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Sets up `mccabe` as an entrypoint to `python -m mccabe`. This allows mccabe to be installed through [pipx](https://github.com/pypa/pipx):
```
  pipx install mccabe
  mccabe --min 5 mccabe.py
```
