### PR TITLE
Add support for Python 3.11-3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Quality Assurance",
     ],

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Quality Assurance",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    ,py36,py37,py38,py39,py310,pypy,pypy3,flake8
+    ,py{36,37,38,39,310,311,312,py,py3},flake8
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    ,py{36,37,38,39,310,311,312,py,py3},flake8
+    ,py{36,37,38,39,310,311,312,313,py,py3},flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
Tested locally with tox.

One test failed for 3.11 and 3.12, but it also failed in the same way for the existing 3.10.

```pytb
❯ tox -e py310,py311,py312
.pkg: _optional_hooks> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py310: install_package> python -I -m pip install --force-reinstall --no-deps /private/tmp/mccabe/.tox/.tmp/package/4/mccabe-0.7.0.tar.gz
py310: commands[0]> pytest
======================================================================================= test session starts ========================================================================================
platform darwin -- Python 3.10.11, pytest-7.4.2, pluggy-1.3.0
cachedir: .tox/py310/.pytest_cache
rootdir: /private/tmp/mccabe
plugins: hypothesis-6.84.3
collected 16 items

test_mccabe.py .............F..                                                                                                                                                              [100%]

============================================================================================= FAILURES =============================================================================================
____________________________________________________________________________ RegressionTests.test_get_module_complexity ____________________________________________________________________________

self = <test_mccabe.RegressionTests testMethod=test_get_module_complexity>

    def test_get_module_complexity(self):
>       self.assertEqual(0, mccabe.get_module_complexity("mccabe.py"))
E       AssertionError: 0 != 1

test_mccabe.py:239: AssertionError
--------------------------------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------------------------------
mccabe.py:315:1: C901 'main' is too complex (8)
========================================================================================= warnings summary =========================================================================================
test_mccabe.py:248
  /private/tmp/mccabe/test_mccabe.py:248: HypothesisDeprecationWarning: `Healthcheck.all()` is deprecated; use `list(HealthCheck)` instead.
      The `hypothesis codemod` command-line tool can automatically refactor your code to fix this warning.
    suppress_health_check=HealthCheck.all(),  # this is slow and filter-heavy.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== short test summary info ======================================================================================
FAILED test_mccabe.py::RegressionTests::test_get_module_complexity - AssertionError: 0 != 1
============================================================================= 1 failed, 15 passed, 1 warning in 15.82s =============================================================================
py310: exit 1 (16.10 seconds) /private/tmp/mccabe> pytest pid=53848
py310: FAIL ✖ in 17.06 seconds
py311: install_package> python -I -m pip install --force-reinstall --no-deps /private/tmp/mccabe/.tox/.tmp/package/5/mccabe-0.7.0.tar.gz
py311: commands[0]> pytest
======================================================================================= test session starts ========================================================================================
platform darwin -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
cachedir: .tox/py311/.pytest_cache
rootdir: /private/tmp/mccabe
plugins: hypothesis-6.84.3
collected 16 items

test_mccabe.py .............F..                                                                                                                                                              [100%]

============================================================================================= FAILURES =============================================================================================
____________________________________________________________________________ RegressionTests.test_get_module_complexity ____________________________________________________________________________

self = <test_mccabe.RegressionTests testMethod=test_get_module_complexity>

    def test_get_module_complexity(self):
>       self.assertEqual(0, mccabe.get_module_complexity("mccabe.py"))
E       AssertionError: 0 != 1

test_mccabe.py:239: AssertionError
--------------------------------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------------------------------
mccabe.py:315:1: C901 'main' is too complex (8)
========================================================================================= warnings summary =========================================================================================
test_mccabe.py:248
  /private/tmp/mccabe/test_mccabe.py:248: HypothesisDeprecationWarning: `Healthcheck.all()` is deprecated; use `list(HealthCheck)` instead.
      The `hypothesis codemod` command-line tool can automatically refactor your code to fix this warning.
    suppress_health_check=HealthCheck.all(),  # this is slow and filter-heavy.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== short test summary info ======================================================================================
FAILED test_mccabe.py::RegressionTests::test_get_module_complexity - AssertionError: 0 != 1
============================================================================= 1 failed, 15 passed, 1 warning in 15.39s =============================================================================
py311: exit 1 (15.64 seconds) /private/tmp/mccabe> pytest pid=53860
py311: FAIL ✖ in 16.33 seconds
py312: install_package> python -I -m pip install --force-reinstall --no-deps /private/tmp/mccabe/.tox/.tmp/package/6/mccabe-0.7.0.tar.gz
py312: commands[0]> pytest
======================================================================================= test session starts ========================================================================================
platform darwin -- Python 3.12.0rc1, pytest-7.4.2, pluggy-1.3.0
cachedir: .tox/py312/.pytest_cache
rootdir: /private/tmp/mccabe
plugins: hypothesis-6.84.3
collected 16 items

test_mccabe.py .............F..                                                                                                                                                              [100%]

============================================================================================= FAILURES =============================================================================================
____________________________________________________________________________ RegressionTests.test_get_module_complexity ____________________________________________________________________________

self = <test_mccabe.RegressionTests testMethod=test_get_module_complexity>

    def test_get_module_complexity(self):
>       self.assertEqual(0, mccabe.get_module_complexity("mccabe.py"))
E       AssertionError: 0 != 1

test_mccabe.py:239: AssertionError
--------------------------------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------------------------------
mccabe.py:315:1: C901 'main' is too complex (8)
========================================================================================= warnings summary =========================================================================================
test_mccabe.py:248
  /private/tmp/mccabe/test_mccabe.py:248: HypothesisDeprecationWarning: `Healthcheck.all()` is deprecated; use `list(HealthCheck)` instead.
      The `hypothesis codemod` command-line tool can automatically refactor your code to fix this warning.
    suppress_health_check=HealthCheck.all(),  # this is slow and filter-heavy.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== short test summary info ======================================================================================
FAILED test_mccabe.py::RegressionTests::test_get_module_complexity - AssertionError: 0 != 1
============================================================================= 1 failed, 15 passed, 1 warning in 14.56s =============================================================================
py312: exit 1 (14.82 seconds) /private/tmp/mccabe> pytest pid=53873
.pkg: _exit> python /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py310: FAIL code 1 (17.06=setup[0.96]+cmd[16.10] seconds)
  py311: FAIL code 1 (16.33=setup[0.69]+cmd[15.64] seconds)
  py312: FAIL code 1 (16.66=setup[1.84]+cmd[14.82] seconds)
  evaluation failed :( (50.14 seconds)
```